### PR TITLE
Remove unnecessary classes on word-count and binary

### DIFF
--- a/binary/binary_test.lua
+++ b/binary/binary_test.lua
@@ -4,50 +4,51 @@ describe('binary', function()
 
   it('1 is decimal 1', function()
     local expected = 1
-    local result = Binary(1).toDecimal()
+    local result = Binary.toDecimal('1')
     assert.are.equals(expected, result)
   end)
 
   it('10 is decimal 2', function()
     local expected = 2
-    local result = Binary('10').toDecimal()
+    local result = Binary.toDecimal('10')
     assert.are.equals(expected, result)
   end)
 
   it('11 is decimal 3', function()
     local expected = 3
-    local result = Binary('11').toDecimal()
+    local result = Binary.toDecimal('11')
     assert.are.equals(expected, result)
   end)
 
   it('100 is decimal 4', function()
     local expected = 4
-    local result = Binary('100').toDecimal()
+    local result = Binary.toDecimal('100')
     assert.are.equals(expected, result)
   end)
 
   it('1001 is decimal 9', function()
     local expected = 9
-    local result = Binary('1001').toDecimal()
+    local result = Binary.toDecimal('1001')
     assert.are.equals(expected, result)
   end)
 
   it('11010 is decimal 26', function()
     local expected = 26
-    local result = Binary('11010').toDecimal()
+    local result = Binary.toDecimal('11010')
     assert.are.equals(expected, result)
   end)
 
   it('10001101000 is decimal 1128', function()
     local expected = 1128
-    local result = Binary('10001101000').toDecimal()
+    local result = Binary.toDecimal('10001101000')
     assert.are.equals(expected, result)
   end)
 
   it('carrot is decimal 0', function()
     local expected = 0
-    local result = Binary('carrot').toDecimal()
+    local result = Binary.toDecimal('carrot')
     assert.are.equals(expected, result)
   end)
 
 end)
+

--- a/binary/example.lua
+++ b/binary/example.lua
@@ -1,18 +1,18 @@
-function Binary(input) 
-  return {
-    toDecimal = function() 
-      if (string.match(input,"%D")) then 
-        return 0
-      end  
-      local str = string.reverse(input)
-      local decimal = 0
-      for i = 1, #str do
-          local c = str:sub(i,i)
-          decimal = decimal + c * (2^(i-1))
-      end
-      return decimal
-    end   
-  }
+local function toDecimal(input)
+  if (string.match(input,"%D")) then
+    return 0
+  end
+  local str = string.reverse(input)
+  local decimal = 0
+  for i = 1, #str do
+      local c = str:sub(i,i)
+      decimal = decimal + c * (2^(i-1))
+  end
+  return decimal
 end
 
-return Binary
+
+return {
+  toDecimal = toDecimal
+}
+

--- a/word-count/example.lua
+++ b/word-count/example.lua
@@ -1,22 +1,12 @@
-local Words = {}
-
-function Words:new(phrase)
-  self.__index = self
-  return setmetatable({phrase = phrase:lower()}, self)
-end
-
-
-function Words:count()
-  local iter = string.gmatch(self.phrase, "%w+")
-  local result = {}
-  for element in iter do
-    if result[element] == nil then
-      result[element] = 1
-    else
-      result[element] = result[element] + 1
+local function word_count(s)
+    local counts = {}
+    for w in s:gmatch('%w+') do
+        local normalized = w:lower()
+        counts[normalized] = (counts[normalized] or 0) + 1
     end
-  end
-  return result
+    return counts
 end
 
-return Words
+return {
+    word_count = word_count,
+}

--- a/word-count/word-count_test.lua
+++ b/word-count/word-count_test.lua
@@ -1,39 +1,39 @@
-local Words = require('words')
+local word_count = require('words').word_count
 
 describe('Words', function()
 
   it('counts one word', function()
-    local result = Words:new('word'):count()
+    local result = word_count('word')
     local expected = { word = 1 }
     assert.are.same(expected, result)
   end)
 
   it('counts one of each', function()
-    local result = Words:new('one of each'):count()
+    local result = word_count('one of each')
     local expected = { one = 1, of = 1, each = 1 }
     assert.are.same(expected, result)
   end)
 
   it('counts multiple occurrences', function()
-    local result = Words:new('one fish two fish red fish blue fish'):count()
+    local result = word_count('one fish two fish red fish blue fish')
     local expected = { one= 1, fish = 4, two = 1, red = 1, blue = 1 }
     assert.are.same(expected, result)
   end)
 
   it('ignores punctuation', function()
-    local result = Words:new('car : carpet as java : javascript!!&@$%^&'):count()
+    local result = word_count('car : carpet as java : javascript!!&@$%^&')
     local expected = { car = 1, carpet = 1, as = 1, java = 1, javascript = 1 }
     assert.are.same(expected, result)
   end)
 
   it('includes numbers', function()
-    local result = Words:new('testing, 1, 2 testing'):count()
+    local result = word_count('testing, 1, 2 testing')
     local expected = { testing = 2, ['1'] = 1, ['2'] = 1 }
     assert.are.same(expected, result)
   end)
 
   it('normalizes case', function()
-    local result = Words:new('go Go GO'):count()
+    local result = word_count('go Go GO')
     local expected = { go = 3 }
     assert.are.same(expected, result)
   end)


### PR DESCRIPTION
I believe such simple exercises do not need the unnecessary coding overhead of creating classes, so I changed them into single  functions.