### PR TITLE
Modules as tables on scrabble-score and roman-numerals

### DIFF
--- a/roman-numerals/example.lua
+++ b/roman-numerals/example.lua
@@ -57,4 +57,4 @@ local toRoman = function(number)
     return roman_number
 end
 
-return toRoman
+return {toRoman = toRoman}

--- a/roman-numerals/roman-numerals_test.lua
+++ b/roman-numerals/roman-numerals_test.lua
@@ -1,4 +1,4 @@
-local toRoman = require('roman-numerals')
+local toRoman = require('roman-numerals').toRoman
 
 describe("toRoman()", function()
     it("converts 1", function()

--- a/scrabble-score/example.lua
+++ b/scrabble-score/example.lua
@@ -1,4 +1,4 @@
-local Score = function(word)
+local function score(word)
     local letterValue = {
         A = 1,
         B = 3,
@@ -35,4 +35,5 @@ local Score = function(word)
     end
     return total
 end
-return Score
+
+return {score = score}

--- a/scrabble-score/scrabble-score_test.lua
+++ b/scrabble-score/scrabble-score_test.lua
@@ -1,4 +1,5 @@
-local score = require('scrabble-score')
+local score = require('scrabble-score').score
+
 
 describe('Scrabble', function()
     it("scores an empty word as zero", function()


### PR DESCRIPTION
Ever since the extinguishing of `module()` the "lunatic" way of making modules is to return a table with the module's content.