### PR TITLE
Fix grains (sample solution and assertion order)

### DIFF
--- a/grains/example.lua
+++ b/grains/example.lua
@@ -1,7 +1,7 @@
 local Grains = {}
 
 function Grains.square(n)
-    return 2 ^ (n - 1)
+    return (1 << (n - 1))
 end
 
 function Grains.total()

--- a/grains/grains_test.lua
+++ b/grains/grains_test.lua
@@ -33,4 +33,5 @@ describe('Grains', function()
     it('total', function()
         assert.are.equals(18446744073709551615, Grains.total())
     end)
+
 end)

--- a/grains/grains_test.lua
+++ b/grains/grains_test.lua
@@ -3,34 +3,34 @@ local Grains = require('grains')
 describe('Grains', function()
 
     it('square 1', function()
-        assert.are.equals(Grains.square(1), 1)
+        assert.are.equals(1, Grains.square(1))
     end)
 
     it('square 2', function()
-        assert.are.equals(Grains.square(2), 2)
+        assert.are.equals(2, Grains.square(2))
     end)
 
     it('square 3', function()
-        assert.are.equals(Grains.square(3), 4)
+        assert.are.equals(4, Grains.square(3))
     end)
 
     it('square 4', function()
-        assert.are.equals(Grains.square(4), 8)
+        assert.are.equals(8, Grains.square(4))
     end)
 
     it('square 16', function()
-        assert.are.equals(Grains.square(16), 32768)
+        assert.are.equals(32768, Grains.square(16))
     end)
 
     it('square 32', function()
-        assert.are.equals(Grains.square(32), 2147483648)
+        assert.are.equals(2147483648, Grains.square(32))
     end)
 
     it('square 64', function()
-        assert.are.equals(Grains.square(64), 9223372036854775808)
+        assert.are.equals(9223372036854775808, Grains.square(64))
     end)
 
     it('total', function()
-        assert.are.equals(Grains.total(), 18446744073709551615)
+        assert.are.equals(18446744073709551615, Grains.total())
     end)
 end)


### PR DESCRIPTION
- The sample solution did not work; fixed by using bitwise operator to ensure that 64-bit integers are used
- Assertion argument order was messed up so that the expected value was given as the actual value and vice-versa; reordered