### PR TITLE
Use Lua's built-in tostring instead of tostring method defined on Clock

### DIFF
--- a/clock/clock_test.lua
+++ b/clock/clock_test.lua
@@ -54,6 +54,6 @@ describe("Clock", function()
 
     it("wraps around midnight backwards", function()
         local clock = clock.at(0, 3):minus(4)
-        assert.are.equals("23:59", clock:tostring())
+        assert.are.equals("23:59", tostring(clock))
     end)
 end)


### PR DESCRIPTION
For whatever reason the clock tests use both `tostring(clock)` and `clock:tostring()`. This seems needlessly confusing and non-idiomatic so I modified the tests to only  use the built-in `tostring`.