### PR TITLE
Updated prime factors tests to not depend upon global variables

### DIFF
--- a/prime-factors/example.lua
+++ b/prime-factors/example.lua
@@ -1,4 +1,4 @@
-function PrimeFactors(input)
+local function PrimeFactors(input)
   local pf = {}
   local i = 2
   while (input ~= 1) do

--- a/prime-factors/prime-factors_test.lua
+++ b/prime-factors/prime-factors_test.lua
@@ -3,47 +3,47 @@ local primeFactors = require('prime-factors')
 describe('primeFactors', function()
 
   it('returns an empty array for 1', function()
-    assert.are.same({}, PrimeFactors(1))
+    assert.are.same({}, primeFactors(1))
   end)
 
   it('factors 2', function()
-    assert.are.same({2}, PrimeFactors(2))
+    assert.are.same({2}, primeFactors(2))
   end)
 
   it('factors 3', function()
-    assert.are.same({3}, PrimeFactors(3))
+    assert.are.same({3}, primeFactors(3))
   end)
 
   it('factors 4', function()
-    assert.are.same({2, 2}, PrimeFactors(4))
+    assert.are.same({2, 2}, primeFactors(4))
   end)
 
   it('factors 6', function()
-    assert.are.same({2, 3}, PrimeFactors(6))
+    assert.are.same({2, 3}, primeFactors(6))
   end)
 
   it('factors 8', function()
-    assert.are.same({2, 2, 2}, PrimeFactors(8))
+    assert.are.same({2, 2, 2}, primeFactors(8))
   end)
 
   it('factors 9', function()
-    assert.are.same({3, 3}, PrimeFactors(9))
+    assert.are.same({3, 3}, primeFactors(9))
   end)
 
   it('factors 27', function()
-    assert.are.same({3, 3, 3}, PrimeFactors(27))
+    assert.are.same({3, 3, 3}, primeFactors(27))
   end)
 
   it('factors 625', function()
-    assert.are.same({5, 5, 5, 5}, PrimeFactors(625))
+    assert.are.same({5, 5, 5, 5}, primeFactors(625))
   end)
 
   it('factors 901255', function()
-    assert.are.same({5, 17, 23, 461}, PrimeFactors(901255))
+    assert.are.same({5, 17, 23, 461}, primeFactors(901255))
   end)
 
   it('factors 93819012551', function()
-    assert.are.same({11, 9539, 894119}, PrimeFactors(93819012551))
+    assert.are.same({11, 9539, 894119}, primeFactors(93819012551))
   end)
 
 end)


### PR DESCRIPTION
The prime factors tests depend upon a global variable being defined in `prime-factors.lua`. This change removes the global from the sample solution and updates the tests to use the function exported from the source file.

I'm honestly surprised that this worked and I think it might be due to a pecularity in busted. I'm fairly certain that global variables can't escape modules in vanilla Lua.