### PR TITLE
circular-buffer: Test overwrite on non-full buffer

### DIFF
--- a/circular-buffer/circular-buffer_test.lua
+++ b/circular-buffer/circular-buffer_test.lua
@@ -79,6 +79,15 @@ describe("CircularBuffer", function()
         assert.has_error((function() buffer:read() end), "buffer is empty")
     end)
 
+    it("forced writes act like normal writes in a non-full buffer", function()
+        local buffer = CircularBuffer:new(2)
+        buffer:write('1')
+        buffer:forceWrite('2')
+        assert.are.equals('1', buffer:read())
+        assert.are.equals('2', buffer:read())
+        assert.has_error((function() buffer:read() end), "buffer is empty")
+    end)
+
     it("alternate force write and read into full buffer", function()
         local buffer = CircularBuffer:new(5)
         for i = 1, 3 do


### PR DESCRIPTION
Following suit with other language tracks:

Ruby:
https://github.com/exercism/xruby/commit/5560b7a0e032bdf4bca753d4aba4625340853d1c

Go:
https://github.com/exercism/xgo/commit/6b41d2f925a7b35140701a8290e7d9a6155ac315

Rust:
https://github.com/exercism/xrust/commit/e4990f1b0e8c9d16053012b13aaaeb03ac141383

Javscript:
https://github.com/exercism/xjavascript/commit/301dd0069e5cd60f336c6a622fac1ea9f3fd1357