### PR TITLE
Track unique accesses to traced arrays for binary search, not total accesses

### DIFF
--- a/binary-search/TracedArray.lua
+++ b/binary-search/TracedArray.lua
@@ -1,9 +1,14 @@
 return function(array)
+  local accessed = {}
+
   return setmetatable({
     access_count = 0
   }, {
     __index = function(self, i)
-      self.access_count = self.access_count + 1
+      if not accessed[i] then
+        self.access_count = self.access_count + 1
+        accessed[i] = true
+      end
       return array[i]
     end,
     __len = function()


### PR DESCRIPTION
Closes #84 