### PR TITLE
largest-series-product: Test for empty digits nonzero span

### DIFF
--- a/exercises/largest-series-product/largest-series-product_spec.lua
+++ b/exercises/largest-series-product/largest-series-product_spec.lua
@@ -58,6 +58,12 @@ describe('largest series product', function()
     end)
   end)
 
+  it('should reject no digits and non-zero span', function()
+    assert.has_error(function()
+      lsp({ digits = '', span = 1 })
+    end)
+  end)
+
   it('should reject negative spans', function()
     assert.has_error(function()
       lsp({ digits = '12345', span = -1 })


### PR DESCRIPTION
At first glance, you might say that this is already being handled by the
case that ensures that the span is less than the number of digits in the
string.

But actually I argue it is important to have this case, to ensure that a
solution of the form "return 1 if the string is empty" does not pass the
tests. Such a solution would be wrong and it would have to be caught by
this particular test.