### PR TITLE
Remove blank lines just inside describe blocks

### DIFF
--- a/exercises/accumulate/accumulate_spec.lua
+++ b/exercises/accumulate/accumulate_spec.lua
@@ -1,7 +1,6 @@
 local accumulate = require('accumulate')
 
 describe('accumulate', function()
-
   local function square(x) return x * x end
 
   it('should accumulate over an empty array', function()
@@ -25,5 +24,4 @@ describe('accumulate', function()
     accumulate(input, square)
     assert.are.same({ 1, 2, 3 }, input)
   end)
-
 end)

--- a/exercises/acronym/acronym_spec.lua
+++ b/exercises/acronym/acronym_spec.lua
@@ -1,7 +1,6 @@
 local acronym = require('acronym')
 
 describe('acronym', function()
-
   it('should generate single-letter acronyms', function()
     assert.equal('L', acronym('Lua'))
   end)
@@ -25,5 +24,4 @@ describe('acronym', function()
   it('should not split words that are all uppercase', function()
     assert.equal('PHP', acronym('PHP: Hypertext Processor'))
   end)
-
 end)

--- a/exercises/allergies/allergies_spec.lua
+++ b/exercises/allergies/allergies_spec.lua
@@ -1,7 +1,6 @@
 local allergies = require('allergies')
 
 describe('allergies', function()
-
   it('should return an empty list of allergies for a score of 0', function()
     assert.same({}, allergies.list(0))
   end)
@@ -84,5 +83,4 @@ describe('allergies', function()
     assert.is_true(allergies.allergic_to(5, 'shellfish'))
     assert.is_false(allergies.allergic_to(5, 'peanuts'))
   end)
-
 end)

--- a/exercises/alphametics/alphametics_spec.lua
+++ b/exercises/alphametics/alphametics_spec.lua
@@ -1,7 +1,6 @@
 local alphametics = require('alphametics')
 
 describe('alphametics', function()
-
   it('should solve short puzzles', function()
     local actual = alphametics.solve('I + BB == ILL')
     local expected = { I = 1, B = 9, L = 0 }
@@ -25,5 +24,4 @@ describe('alphametics', function()
     local expected = { P = 9, I = 6, R = 7, A = 4, E = 0 }
     assert.same(expected, actual)
   end)
-
 end)

--- a/exercises/anagram/anagram_spec.lua
+++ b/exercises/anagram/anagram_spec.lua
@@ -1,7 +1,6 @@
 local Anagram = require('anagram')
 
 describe('anagram', function()
-
   it('no result', function()
     local detector = Anagram:new('diaper')
     local result = detector:match({ 'hello', 'world', 'zombies', 'pants' })
@@ -57,5 +56,4 @@ describe('anagram', function()
     local expected = { 'Carthorse' }
     assert.are.same(expected, result)
   end)
-
 end)

--- a/exercises/atbash-cipher/atbash-cipher_spec.lua
+++ b/exercises/atbash-cipher/atbash-cipher_spec.lua
@@ -1,7 +1,6 @@
 local encode = require('atbash-cipher').encode
 
 describe('atbash-cipher', function()
-
   it('should encode single letter plaintexts', function()
     assert.are.equal('m', encode('n'))
   end)
@@ -36,5 +35,4 @@ describe('atbash-cipher', function()
       encode('The quick brown fox jumps over the lazy dog.')
     )
   end)
-
 end)

--- a/exercises/bank-account/bank-account_spec.lua
+++ b/exercises/bank-account/bank-account_spec.lua
@@ -1,7 +1,6 @@
 local BankAccount = require('bank-account')
 
 describe('bank-ccount', function()
-
   it('should have a balance of zero after opening a new account', function()
     local account = BankAccount:new()
     assert.equal(0, account:balance())
@@ -93,5 +92,4 @@ describe('bank-ccount', function()
       account:withdraw(1)
     end)
   end)
-
 end)

--- a/exercises/beer-song/beer-song_spec.lua
+++ b/exercises/beer-song/beer-song_spec.lua
@@ -1,7 +1,6 @@
 local beer = require('beer-song')
 
 describe('beer-song', function()
-
   it('prints an arbitrary verse', function()
     local expected = '8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n'
     local result = beer.verse(8)
@@ -31,5 +30,4 @@ describe('beer-song', function()
     local result = beer.sing(3)
     assert.are.equal(expected, result)
   end)
-
 end)

--- a/exercises/binary-search-tree/binary-search-tree_spec.lua
+++ b/exercises/binary-search-tree/binary-search-tree_spec.lua
@@ -1,7 +1,6 @@
 local BinarySearchTree = require('binary-search-tree')
 
 describe('binary-search-tree', function()
-
   it('should maintain a value for each node', function()
     assert.equal(4, BinarySearchTree:new(4).value)
   end)
@@ -76,5 +75,4 @@ describe('binary-search-tree', function()
 
     assert.same(expected, actual)
   end)
-
 end)

--- a/exercises/binary-search/binary-search_spec.lua
+++ b/exercises/binary-search/binary-search_spec.lua
@@ -2,7 +2,6 @@ local find = require('binary-search')
 local TracedArray = require('TracedArray')
 
 describe('binary-search', function()
-
   it('should return -1 when an empty array is searched', function()
     local array = TracedArray{}
 
@@ -64,5 +63,4 @@ describe('binary-search', function()
     assert.equal(-1, find(array, 54323))
     assert(array.access_count <= 4)
   end)
-
 end)

--- a/exercises/binary/binary_spec.lua
+++ b/exercises/binary/binary_spec.lua
@@ -1,7 +1,6 @@
 local binary = require('binary')
 
 describe('binary', function()
-
   it('1 is decimal 1', function()
     local expected = 1
     local actual = binary.to_decimal('1')
@@ -49,5 +48,4 @@ describe('binary', function()
     local actual = binary.to_decimal('carrot')
     assert.are.equals(expected, actual)
   end)
-
 end)

--- a/exercises/bob/bob_spec.lua
+++ b/exercises/bob/bob_spec.lua
@@ -1,7 +1,6 @@
 local bob = require('bob')
 
 describe('bob', function()
-
   it('stating something', function()
     local result = bob.hey('Tom-ay-to, tom-aaaah-to.')
     assert.are.equals('Whatever', result)
@@ -36,5 +35,4 @@ describe('bob', function()
     local result = bob.hey('')
     assert.are.equals('Fine, be that way.', result)
   end)
-
 end)

--- a/exercises/bowling/bowling_spec.lua
+++ b/exercises/bowling/bowling_spec.lua
@@ -1,7 +1,6 @@
 local BowlingScorer = require('bowling')
 
 describe('bowling', function()
-
   local scorer
 
   before_each(function()
@@ -142,5 +141,4 @@ describe('bowling', function()
     assert.equal(60, s1.score())
     assert.equal(40, s2.score())
   end)
-
 end)

--- a/exercises/bracket-push/bracket-push_spec.lua
+++ b/exercises/bracket-push/bracket-push_spec.lua
@@ -1,7 +1,6 @@
 local brackets = require('bracket-push')
 
 describe('bracket-push', function()
-
   it('should accept an empty string', function()
     assert.is_true(brackets.valid(''))
   end)
@@ -73,5 +72,4 @@ describe('bracket-push', function()
   it('should ignore non-bracket characters', function()
     assert.is_true(brackets.valid('{hello[]([a()])b}c'))
   end)
-
 end)

--- a/exercises/change/change_spec.lua
+++ b/exercises/change/change_spec.lua
@@ -1,7 +1,6 @@
 local change = require('change')
 
 describe('change', function()
-
   it('should generate the correct change when there is only one type of coin', function()
     assert.same({ 5 }, change(5, { 1 }))
   end)
@@ -26,5 +25,4 @@ describe('change', function()
   it('should generate the correct change for large values with many coins', function()
     assert.same({ 3, 1, 0, 1, 1 }, change(133, { 1, 5, 10, 25, 100 }))
   end)
-
 end)

--- a/exercises/circular-buffer/circular-buffer_spec.lua
+++ b/exercises/circular-buffer/circular-buffer_spec.lua
@@ -1,7 +1,6 @@
 local CircularBuffer = require('circular-buffer')
 
 describe('circular-buffer', function()
-
   it('reading an empty buffer throws a BufferEmptyException', function()
     local buffer = CircularBuffer:new(1)
     assert.has_error((function() buffer:read() end), 'buffer is empty')
@@ -109,5 +108,4 @@ describe('circular-buffer', function()
     assert.are.equals('B', buffer:read())
     assert.has_error((function() buffer:read() end), 'buffer is empty')
   end)
-
 end)

--- a/exercises/clock/clock_spec.lua
+++ b/exercises/clock/clock_spec.lua
@@ -1,7 +1,6 @@
 local clock = require('clock')
 
 describe('clock', function()
-
   it('prints the hour', function()
     assert.are.equals('08:00', tostring(clock.at(8)))
     assert.are.equals('09:00', tostring(clock.at(9)))
@@ -56,5 +55,4 @@ describe('clock', function()
     local clock = clock.at(0, 3):minus(4)
     assert.are.equals('23:59', tostring(clock))
   end)
-
 end)

--- a/exercises/crypto-square/crypto-square_spec.lua
+++ b/exercises/crypto-square/crypto-square_spec.lua
@@ -1,9 +1,7 @@
 local cs = require('crypto-square')
 
 describe('crypto-square', function()
-
   describe('normalized_plaintext', function()
-
     it('should convert all uppercase letters to lowercase', function()
       assert.equal('abcdefg', cs.normalized_plaintext('AbcDEfG'))
     end)
@@ -20,11 +18,9 @@ describe('crypto-square', function()
     it('should retain numbers', function()
       assert.equal('hello123', cs.normalized_plaintext('hello123'))
     end)
-
   end)
 
   describe('size', function()
-
     it('should determine the size of a small perfect square', function()
       assert.equal(2, cs.size('1234'))
     end)
@@ -40,11 +36,9 @@ describe('crypto-square', function()
     it('should determine the size based on normalized plaintext', function()
       assert.equal(4, cs.size('Oh hey, this is nuts!'))
     end)
-
   end)
 
   describe('segments', function()
-
     it('should split plaintext into segments of size', function()
       assert.same(
         { 'neverv', 'exthin', 'eheart', 'withid', 'lewoes' },
@@ -58,11 +52,9 @@ describe('crypto-square', function()
         cs.segments('ZOMG! ZOMBIES!!!')
       )
     end)
-
   end)
 
   describe('ciphertext', function()
-
     it('should generate ciphertext for a string', function()
       assert.equal(
         'wneiaweoreneawssciliprerlneoidktcms',
@@ -76,11 +68,9 @@ describe('crypto-square', function()
         cs.ciphertext('Time is an illusion. Lunchtime doubly so.')
       )
     end)
-
   end)
 
   describe('normalized_ciphertext', function()
-
     it('should generate normalized ciphertext', function()
       assert.equal(
         'vrel aepe mset paoo irpo',
@@ -98,7 +88,5 @@ describe('crypto-square', function()
     it('should generate normalized ciphertext when just less than a full square', function()
       assert.equal('im a', cs.normalized_ciphertext('I am'))
     end)
-
   end)
-
 end)

--- a/exercises/custom-set/custom-set_spec.lua
+++ b/exercises/custom-set/custom-set_spec.lua
@@ -1,9 +1,7 @@
 local Set = require('custom-set')
 
 describe('custom-set', function()
-
   describe('equality', function()
-
     it('should ignore order', function()
       assert.is_true(Set(1, 3):equals(Set(3, 1)))
     end)
@@ -36,11 +34,9 @@ describe('custom-set', function()
     it('should not consider sets that have a large but incomplete intersection to be equal', function()
       assert.is_false(Set(1, 2, 3, 4):equals(Set(2, 3, 4, 5)))
     end)
-
   end)
 
   describe('add', function()
-
     it('should allow an element to be added to an empty set', function()
       local s = Set()
       s:add(3)
@@ -58,11 +54,9 @@ describe('custom-set', function()
       s:add(3)
       assert.is_true(s:equals(Set(1, 2, 3)))
     end)
-
   end)
 
   describe('delete', function()
-
     it('should allow an element to be deleted from a set', function()
       local s = Set(3, 2, 1)
       s:remove(2)
@@ -74,11 +68,9 @@ describe('custom-set', function()
       s:remove(4)
       assert.is_true(s:equals(Set(1, 2, 3)))
     end)
-
   end)
 
   describe('is_empty', function()
-
     it('should indicate that an empty set is empty', function()
       assert.is_true(Set():is_empty())
     end)
@@ -90,11 +82,9 @@ describe('custom-set', function()
     it('should indicate that a set with multiple elements is non-empty', function()
       assert.is_false(Set(1, 2, 3):is_empty())
     end)
-
   end)
 
   describe('size', function()
-
     it('should give the size of an empty set as 0', function()
       assert.equals(0, Set():size())
     end)
@@ -106,11 +96,9 @@ describe('custom-set', function()
     it('should ignore duplicate elements', function()
       assert.equals(3, Set(1, 2, 3, 2):size())
     end)
-
   end)
 
   describe('contains', function()
-
     it('should indicate that nothing is an element of an empty set', function()
       assert.is_false(Set():contains(1))
     end)
@@ -124,11 +112,9 @@ describe('custom-set', function()
     it('should indicate that an element that is not in a set is not contained in the set', function()
       assert.is_false(Set(1, 2, 3, 2):contains(4))
     end)
-
   end)
 
   describe('is_subset', function()
-
     it('should indicate that an empty set is a subset of itself', function()
       assert.is_true(Set():is_subset(Set()))
     end)
@@ -160,11 +146,9 @@ describe('custom-set', function()
     it('should not indicate that a set is a subset of a set with different but more elements', function()
       assert.is_false(Set(1, 2, 3, 11):is_subset(Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
     end)
-
   end)
 
   describe('is_disjoint', function()
-
     it('should indicate that the empty set is disjoint with itself', function()
       assert.is_true(Set():is_disjoint(Set()))
     end)
@@ -184,11 +168,9 @@ describe('custom-set', function()
     it('should indicate that sets with no elements in common are disjoint', function()
       assert.is_true(Set(1, 2):is_disjoint(Set(3, 4)))
     end)
-
   end)
 
   describe('intersection', function()
-
     it('should give the empty set as the intersection of two empty sets', function()
       assert.is_true(Set():intersection(Set()):equals(Set()))
     end)
@@ -220,11 +202,9 @@ describe('custom-set', function()
     it('should intersect sets with no elements in common', function()
       assert.is_true(Set(1, 2, 3):intersection(Set(4, 5, 6)):equals(Set()))
     end)
-
   end)
 
   describe('union', function()
-
     it('should produce the empty set as the union of two empty sets', function()
       assert.is_true(Set():union(Set()):equals(Set()))
     end)
@@ -244,11 +224,9 @@ describe('custom-set', function()
       assert.is_true(Set(1, 3):union(Set(2, 3)):equals(Set(1, 2, 3)))
       assert.is_true(Set(1, 2, 3, 4):union(Set(3, 2, 5)):equals(Set(1, 2, 3, 4, 5)))
     end)
-
   end)
 
   describe('difference', function()
-
     it('should give the difference of two empty sets as the empty set', function()
       assert.is_true(Set():difference(Set()):equals(Set()))
     end)
@@ -269,11 +247,9 @@ describe('custom-set', function()
       assert.is_true(Set(3, 2, 1):difference(Set(2, 4)):equals(Set(1, 3)))
       assert.is_true(Set(1, 2, 3, 4):difference(Set(3, 2, 5)):equals(Set(1, 4)))
     end)
-
   end)
 
   describe('symmetric_difference', function()
-
     it('should give the symmetric difference of two empty sets as the empty set', function()
       assert.is_true(Set():symmetric_difference(Set()):equals(Set()))
     end)
@@ -293,16 +269,12 @@ describe('custom-set', function()
     it('should give the symmetric difference of sets with elements in common', function()
       assert.is_true(Set(3, 2, 1):symmetric_difference(Set(2, 4)):equals(Set(1, 3, 4)))
     end)
-
   end)
 
   describe('mixed types', function()
-
     it('should support non-numeric types', function()
       assert.is_true(Set('a', 'b', 'c'):intersection(Set('a', 'c', 'd')):equals(Set('a', 'c')))
       assert.is_true(Set('a', 'b', 'c'):union(Set('a', 'c', 'd')):equals(Set('a', 'b', 'c', 'd')))
     end)
-
   end)
-
 end)

--- a/exercises/difference-of-squares/difference-of-squares_spec.lua
+++ b/exercises/difference-of-squares/difference-of-squares_spec.lua
@@ -1,36 +1,28 @@
 local diff = require('difference-of-squares')
 
 describe('difference-of-squares', function()
-
   describe('square_of_sums', function()
-
     it('should square the sum of the numbers up to the given number', function()
       assert.equal(225, diff.square_of_sums(5))
       assert.equal(3025, diff.square_of_sums(10))
       assert.equal(25502500, diff.square_of_sums(100))
     end)
-
   end)
 
   describe('sum_of_squares', function()
-
     it('should sum the squares of the numbers up to the given number', function()
       assert.equal(55, diff.sum_of_squares(5))
       assert.equal(385, diff.sum_of_squares(10))
       assert.equal(338350, diff.sum_of_squares(100))
     end)
-
   end)
 
   describe('difference_of_squares', function()
-
     it('should subtract sum of squares from square of sums', function()
       assert.equal(0, diff.difference_of_squares(0))
       assert.equal(170, diff.difference_of_squares(5))
       assert.equal(2640, diff.difference_of_squares(10))
       assert.equal(25164150, diff.difference_of_squares(100))
     end)
-
   end)
-
 end)

--- a/exercises/etl/etl_spec.lua
+++ b/exercises/etl/etl_spec.lua
@@ -1,7 +1,6 @@
 local etl = require('etl')
 
 describe('etl', function()
-
   it('should correctly transform a dataset with a single mapping', function()
     local old = { [1] = { 'A' } }
     local expected = { a = 1 }
@@ -60,5 +59,4 @@ describe('etl', function()
     }
     assert.same(expected, etl.transform(old))
   end)
-
 end)

--- a/exercises/food-chain/food-chain_spec.lua
+++ b/exercises/food-chain/food-chain_spec.lua
@@ -1,7 +1,6 @@
 local song = require('food-chain')
 
 describe('food-hain', function ()
-
   it('fly', function ()
     local expected = "I know an old lady who swallowed a fly.\nI don't know why she swallowed the fly. Perhaps she'll die.\n"
 
@@ -101,5 +100,4 @@ describe('food-hain', function ()
   it('the whole song', function ()
     assert.are.equal(song.verses(1, 8), song.sing())
   end)
-
 end)

--- a/exercises/gigasecond/gigasecond_spec.lua
+++ b/exercises/gigasecond/gigasecond_spec.lua
@@ -1,7 +1,6 @@
 local gigasecond = require('gigasecond')
 
 describe('gigasecond', function()
-
   it('test 1', function()
     local actual = gigasecond.anniversary(os.time({ year = 2011, month = 3, day = 25, hour = 0, min = 0, sec = 0 }))
     local expectedDate = os.date('%x', os.time({ year = 2042, month = 12, day = 1, hour = 0, min = 0, sec = 0 }))
@@ -25,5 +24,4 @@ describe('gigasecond', function()
     local expectedDate = os.date('%x', os.time({ year = 2025, month = 4, day = 25 }))
     assert.are.equals(expectedDate, actual)
   end)
-
 end)

--- a/exercises/grade-school/grade-school_spec.lua
+++ b/exercises/grade-school/grade-school_spec.lua
@@ -1,7 +1,6 @@
 local School = require('grade-school')
 
 describe('grade-school', function()
-
   it('a new school has an empty roster', function()
     local school = School:new()
     local expected = {}
@@ -67,5 +66,4 @@ describe('grade-school', function()
     local result = school:roster()
     assert.are.same(expected, result)
   end)
-
 end)

--- a/exercises/grains/grains_spec.lua
+++ b/exercises/grains/grains_spec.lua
@@ -1,7 +1,6 @@
 local grains = require('grains')
 
 describe('grains', function()
-
   it('square 1', function()
     assert.are.equals(1, grains.square(1))
   end)
@@ -33,5 +32,4 @@ describe('grains', function()
   it('total', function()
     assert.are.equals(18446744073709551615, grains.total())
   end)
-
 end)

--- a/exercises/hamming/hamming_spec.lua
+++ b/exercises/hamming/hamming_spec.lua
@@ -1,7 +1,6 @@
 local compute = require('hamming').compute
 
 describe('hamming', function ()
-
   it('no difference between identical strands', function ()
      assert.are.equals(0, compute('A', 'A'))
   end)
@@ -45,5 +44,4 @@ describe('hamming', function ()
   it('empty strands', function ()
     assert.are.equals(0, compute('', ''))
   end)
-
 end)

--- a/exercises/hello-world/hello-world_spec.lua
+++ b/exercises/hello-world/hello-world_spec.lua
@@ -1,7 +1,6 @@
 local hello_world = require('hello-world')
 
 describe('hello-world', function()
-
   it('says hello world with no name', function()
     local result = hello_world.hello()
     assert.are.equals('Hello, world!', result)

--- a/exercises/house/house_spec.lua
+++ b/exercises/house/house_spec.lua
@@ -82,7 +82,6 @@ that lay in the house that Jack built.]]
 }
 
 describe('house', function()
-
   it('should correctly generate the first verse', function()
     assert.equal(verses[1], house.verse(1))
   end)
@@ -96,5 +95,4 @@ describe('house', function()
   it('should recite the entire song', function()
     assert.equal(table.concat(verses, '\n'), house.recite())
   end)
-
 end)

--- a/exercises/kindergarten-garden/kindergarten-garden_spec.lua
+++ b/exercises/kindergarten-garden/kindergarten-garden_spec.lua
@@ -1,7 +1,6 @@
 local Garden = require('kindergarten-garden')
 
 describe('kindergarten-garden', function()
-
   it('should be able to parse a garden with only one student', function()
     local garden = Garden('RC\nGG')
     assert.same({ 'radishes', 'clover', 'grass', 'grass' }, garden.alice)
@@ -48,5 +47,4 @@ describe('kindergarten-garden', function()
     local garden = Garden('RC\nGG')
     assert.same({ 'radishes', 'clover', 'grass', 'grass' }, garden.ALICE)
   end)
-
 end)

--- a/exercises/largest-series-product/largest-series-product_spec.lua
+++ b/exercises/largest-series-product/largest-series-product_spec.lua
@@ -1,7 +1,6 @@
 local lsp = require('largest-series-product')
 
 describe('largest-series-product', function()
-
   it('should be able to find the largest product of 2 with ordered digits', function()
     assert.equals(72, lsp({ digits = '0123456789', span = 2 }))
   end)
@@ -75,5 +74,4 @@ describe('largest-series-product', function()
       lsp({ digits = '1234a5', span = 2 })
     end)
   end)
-
 end)

--- a/exercises/leap/leap_spec.lua
+++ b/exercises/leap/leap_spec.lua
@@ -1,7 +1,6 @@
 local is_leap_year = require('leap')
 
 describe('leap', function()
-
   it('a known leap year', function()
     assert.is_true(is_leap_year(1996))
   end)
@@ -17,5 +16,4 @@ describe('leap', function()
   it('turn of the 21st century', function()
     assert.is_true(is_leap_year(2400))
   end)
-
 end)

--- a/exercises/list-ops/list-ops_spec.lua
+++ b/exercises/list-ops/list-ops_spec.lua
@@ -3,11 +3,9 @@ local reduce = require('list-ops').reduce
 local filter = require('list-ops').filter
 
 describe('list-ops', function()
-
   local function should_not_be_called() error('unexpected call') end
 
   describe('map', function()
-
     local function identity(x) return x end
     local function square(x) return x * x end
 
@@ -28,7 +26,6 @@ describe('list-ops', function()
       map(xs, square)
       assert.same({ 1, 2, 3, 4 }, xs)
     end)
-
   end)
 
   describe('reduce', function()
@@ -61,11 +58,9 @@ describe('list-ops', function()
       reduce(xs, 0, sum)
       assert.same({ 1, 2, 3, 4 }, xs)
     end)
-
   end)
 
   describe('filter', function()
-
     local function always_true() return true end
     local function always_false() return false end
     local function is_even(x) return x %2 == 0 end
@@ -91,7 +86,5 @@ describe('list-ops', function()
       filter(xs, is_even)
       assert.same({ 1, 2, 3, 4 }, xs)
     end)
-
   end)
-
 end)

--- a/exercises/luhn/luhn_spec.lua
+++ b/exercises/luhn/luhn_spec.lua
@@ -1,7 +1,6 @@
 local Luhn = require('luhn')
 
 describe('luhn', function()
-
   it('should give the last digit of a number as the check digit', function()
     assert.equal(7, Luhn.new('34567'):check_digit())
     assert.equal(0, Luhn.new('91370'):check_digit())
@@ -49,5 +48,4 @@ describe('luhn', function()
       Luhn.create('34598754109846124372104312349048732432143214732140498237142')
     )
   end)
-
 end)

--- a/exercises/matrix/matrix_spec.lua
+++ b/exercises/matrix/matrix_spec.lua
@@ -1,7 +1,6 @@
 local Matrix = require('matrix')
 
 describe('matrix', function()
-
   it('should allow rows to be extracted', function()
     local matrix = Matrix('1 2 3\n4 5 6\n7 8 9')
     assert.same({ 1, 2, 3 }, matrix.row(1))
@@ -27,5 +26,4 @@ describe('matrix', function()
     assert.same({ 3, 4 }, matrix.row(2))
     assert.same({ 2, 4, 6 }, matrix.column(2))
   end)
-
 end)

--- a/exercises/minesweeper/minesweeper_spec.lua
+++ b/exercises/minesweeper/minesweeper_spec.lua
@@ -1,7 +1,6 @@
 local minesweeper = require('minesweeper')
 
 describe('minesweeper', function()
-
   it('should be able to transform a 1x1 board with a single mine', function()
     local input = {
       '*-*',
@@ -133,5 +132,4 @@ describe('minesweeper', function()
       minesweeper.transform(input)
     end)
   end)
-
 end)

--- a/exercises/nth-prime/nth-prime_spec.lua
+++ b/exercises/nth-prime/nth-prime_spec.lua
@@ -1,7 +1,6 @@
 local nth = require('nth-prime')
 
 describe('nth-prime', function()
-
   local function benchmark(f)
     local start = os.clock()
     f()
@@ -41,5 +40,4 @@ describe('nth-prime', function()
       nth(-1)
     end)
   end)
-
 end)

--- a/exercises/nucleotide-count/nucleotide-count_spec.lua
+++ b/exercises/nucleotide-count/nucleotide-count_spec.lua
@@ -1,7 +1,6 @@
 local DNA = require('nucleotide-count')
 
 describe('nucleotide-count', function()
-
   it('has no nucleotides', function()
     local expected =  { A = 0, T = 0, C = 0, G = 0 }
     dna = DNA:new('')
@@ -56,5 +55,4 @@ describe('nucleotide-count', function()
     result = dna.nucleotideCounts
     assert.are.same(expected, result)
   end)
-
 end)

--- a/exercises/ocr-numbers/ocr-numbers_spec.lua
+++ b/exercises/ocr-numbers/ocr-numbers_spec.lua
@@ -1,7 +1,6 @@
 local ocr = require('ocr-numbers')
 
 describe('ocr-numbers', function()
-
   it('should recognize zero', function()
     local actual = ocr.convert(
       ' _ \n' ..
@@ -159,5 +158,4 @@ describe('ocr-numbers', function()
     )
     assert.equal('123,456,789', actual)
   end)
-
 end)

--- a/exercises/octal/octal_spec.lua
+++ b/exercises/octal/octal_spec.lua
@@ -1,7 +1,6 @@
 local Octal = require('./octal')
 
 describe('octal', function()
-
   it('should convert 1 to decimal 1', function()
     assert.equal(1, Octal('1').to_decimal())
   end)
@@ -43,5 +42,4 @@ describe('octal', function()
     assert.equal(0, Octal('8').to_decimal())
     assert.equal(0, Octal('9').to_decimal())
   end)
-
 end)

--- a/exercises/pangram/pangram_spec.lua
+++ b/exercises/pangram/pangram_spec.lua
@@ -1,7 +1,6 @@
 local is_pangram = require('pangram')
 
 describe('pangram', function()
-
   it('should not consider the empty string to be a pangram', function()
     assert.is_false(is_pangram(''))
   end)
@@ -37,5 +36,4 @@ describe('pangram', function()
   it('should not consider non-ASCII characters to be letters', function()
     assert.is_false(is_pangram('äbcdefghijklmnopqrstuvwxyz'))
   end)
-
 end)

--- a/exercises/pascals-triangle/pascals-triangle_spec.lua
+++ b/exercises/pascals-triangle/pascals-triangle_spec.lua
@@ -1,7 +1,6 @@
 local Triangle = require('pascals-triangle')
 
 describe('pascals-triangle', function()
-
   it('should generate a triangle with one row', function()
     assert.same({ { 1 } }, Triangle(1).rows)
   end)
@@ -30,5 +29,4 @@ describe('pascals-triangle', function()
     local twentieth = { 1, 19, 171, 969, 3876, 11628, 27132, 50388, 75582, 92378, 92378, 75582, 50388, 27132, 11628, 3876, 969, 171, 19, 1 }
     assert.same(twentieth, Triangle(20).last_row)
   end)
-
 end)

--- a/exercises/perfect-numbers/perfect-numbers_spec.lua
+++ b/exercises/perfect-numbers/perfect-numbers_spec.lua
@@ -1,7 +1,6 @@
 local perfect_numbers = require('perfect-numbers')
 
 describe('perfect-numbers', function()
-
   it('should be able to calculate the Aliquot sum of a number with no divisors', function()
     assert.equal(0, perfect_numbers.aliquot_sum(1))
   end)
@@ -29,5 +28,4 @@ describe('perfect-numbers', function()
   it('should classify numbers whose Aliquot sum is greater than itself as abundant', function()
     assert.equal('abundant', perfect_numbers.classify(12))
   end)
-
 end)

--- a/exercises/phone-number/phone-number_spec.lua
+++ b/exercises/phone-number/phone-number_spec.lua
@@ -1,7 +1,6 @@
 local PhoneNumber = require('phone-number')
 
 describe('phone-number', function()
-
   it('cleans the number (123) 456-7890', function()
     local phone = PhoneNumber:new('(123) 456-7890')
     assert.are.equals('1234567890', phone.number)
@@ -36,5 +35,4 @@ describe('phone-number', function()
     local phone = PhoneNumber:new('1234567890')
     assert.are.equals('(123) 456-7890', tostring(phone))
   end)
-
 end)

--- a/exercises/pig-latin/pig-latin_spec.lua
+++ b/exercises/pig-latin/pig-latin_spec.lua
@@ -1,7 +1,6 @@
 local translate = require('pig-latin')
 
 describe('pig-latin', function()
-
   it('should append "ay" to words beginning with a vowel', function()
     assert.equal('appleay', translate('apple'))
     assert.equal('earay', translate('ear'))
@@ -65,5 +64,4 @@ describe('pig-latin', function()
   it('should retain all whitespace', function()
     assert.equal('abstay\tanday   pacessay', translate('tabs\tand   spaces'))
   end)
-
 end)

--- a/exercises/prime-factors/prime-factors_spec.lua
+++ b/exercises/prime-factors/prime-factors_spec.lua
@@ -1,7 +1,6 @@
 local prime_factors = require('prime-factors')
 
 describe('prime-factors', function()
-
   it('returns an empty array for 1', function()
     assert.are.same({}, prime_factors(1))
   end)
@@ -45,5 +44,4 @@ describe('prime-factors', function()
   it('factors 93819012551', function()
     assert.are.same({ 11, 9539, 894119 }, prime_factors(93819012551))
   end)
-
 end)

--- a/exercises/protein-translation/protein-translation_spec.lua
+++ b/exercises/protein-translation/protein-translation_spec.lua
@@ -1,9 +1,7 @@
 local translate = require('protein-translation')
 
 describe('protein-translation', function()
-
   describe('translate.codon', function()
-
     it('should translate AUG to Methionine', function()
       assert.equal('Methionine', translate.codon('AUG'))
     end)
@@ -48,11 +46,9 @@ describe('protein-translation', function()
     it('should raise an error when an unknown codon is translated', function()
       assert.has_error(function() translate.codon('MIA') end)
     end)
-
   end)
 
   describe('translate.rna_strand', function()
-
     it('should translate each codon in a strand into the corresponding protein', function()
       assert.same({ 'Methionine', 'Phenylalanine', 'Tryptophan' }, translate.rna_strand('AUGUUUUGG'))
     end)
@@ -69,7 +65,5 @@ describe('protein-translation', function()
     it('should not raise an error when an unknown codon occurs after a STOP codon', function()
       assert.same({ 'Cysteine' }, translate.rna_strand('UGUUGACARROT'))
     end)
-
   end)
-
 end)

--- a/exercises/rna-transcription/rna-transcription_spec.lua
+++ b/exercises/rna-transcription/rna-transcription_spec.lua
@@ -1,7 +1,6 @@
 local to_rna = require('rna-transcription')
 
 describe('rna-transcription', function()
-
   it('transcribes cytosine to guanosine', function()
     assert.are.equal('G', to_rna('C'))
   end)
@@ -21,5 +20,4 @@ describe('rna-transcription', function()
   it('transcribes all DNA nucleotides to their RNA complements', function()
     assert.are.equal('UGCACCAGAAUU', to_rna('ACGTGGTCTTAA'))
   end)
-
 end)

--- a/exercises/robot-name/robot-name_spec.lua
+++ b/exercises/robot-name/robot-name_spec.lua
@@ -1,7 +1,6 @@
 local Robot = require('robot-name')
 
 describe('Robot', function()
-
   it('has a name', function()
     local robot = Robot:new()
     -- lua does not support fixed patterns like %w{2}%d{3}
@@ -25,5 +24,4 @@ describe('Robot', function()
     robot:reset()
     assert.are_not.equal(originalName, robot.name)
   end)
-
 end)

--- a/exercises/roman-numerals/roman-numerals_spec.lua
+++ b/exercises/roman-numerals/roman-numerals_spec.lua
@@ -1,7 +1,6 @@
 local to_roman = require('roman-numerals').to_roman
 
 describe('roman-numerals', function()
-
   it('converts 1', function()
     assert.are.equal('I', to_roman(1))
   end)
@@ -73,5 +72,4 @@ describe('roman-numerals', function()
   it('converts 3000', function()
     assert.are.equal('MMM', to_roman(3000))
   end)
-
 end)

--- a/exercises/scrabble-score/scrabble-score_spec.lua
+++ b/exercises/scrabble-score/scrabble-score_spec.lua
@@ -1,7 +1,6 @@
 local score = require('scrabble-score').score
 
 describe('scrabble-score', function()
-
   it('scores an empty word as zero', function()
     assert.are.equal(0, score(''))
   end)
@@ -25,5 +24,4 @@ describe('scrabble-score', function()
   it('scores case insensitive words', function()
     assert.are.equal(20, score('MULTIBILLIONAIRE'))
   end)
-
 end)

--- a/exercises/space-age/space-age_spec.lua
+++ b/exercises/space-age/space-age_spec.lua
@@ -1,7 +1,6 @@
 local SpaceAge = require('space-age')
 
 describe('space-age', function()
-
   it('age in seconds', function()
     local age = SpaceAge:new(1000000)
     assert.are.equal(1000000, age.seconds)
@@ -53,5 +52,4 @@ describe('space-age', function()
     assert.are.equal(260.16, age.on_earth())
     assert.are.equal(1.58, age.on_neptune())
   end)
-
 end)

--- a/exercises/triangle/triangle_spec.lua
+++ b/exercises/triangle/triangle_spec.lua
@@ -1,7 +1,6 @@
 local triangle = require('triangle')
 
 describe('triangle', function()
-
   it('equilateral triangles have equal sides', function()
     assert.are.equals('equilateral', triangle.kind(2, 2, 2))
   end)
@@ -57,5 +56,4 @@ describe('triangle', function()
   it('triangles violating triangle inequality are illegal 2', function()
     assert.has_error(function() triangle.kind(7, 3, 2) end, 'Input Error')
   end)
-
 end)

--- a/exercises/word-count/word-count_spec.lua
+++ b/exercises/word-count/word-count_spec.lua
@@ -1,7 +1,6 @@
 local word_count = require('word-count').word_count
 
 describe('word-count', function()
-
   it('counts one word', function()
     local result = word_count('word')
     local expected = { word = 1 }
@@ -37,5 +36,4 @@ describe('word-count', function()
     local expected = { go = 3 }
     assert.are.same(expected, result)
   end)
-
 end)


### PR DESCRIPTION
For whatever reason, these seem to cause the metalua-based formatter (which seems to power every editor's Lua formatter) to add an extra indent level. This reformatting will allow an auto-formatter to be used in the test files.