### PR TITLE
Improve custom set tests so that # cannot be used to incorrectly calculate size

### DIFF
--- a/exercises/custom-set/custom-set_spec.lua
+++ b/exercises/custom-set/custom-set_spec.lua
@@ -91,6 +91,7 @@ describe('custom-set', function()
 
     it('should determine the size of a non-empty set', function()
       assert.equals(3, Set(1, 2, 3):size())
+      assert.equals(3, Set(4, 5, 6):size())
     end)
 
     it('should ignore duplicate elements', function()


### PR DESCRIPTION
I saw in a solution that `#` was being used to calculate the size of a set and no tests were passing. This change ensures that this failure will be caught.