### PR TITLE
Pig Latin: Always identify prefixes by using lowercased word

### DIFF
--- a/exercises/pig-latin/example.lua
+++ b/exercises/pig-latin/example.lua
@@ -1,7 +1,7 @@
 local function translate(word)
   local function begins_with_any_of(patterns)
     for _, pattern in ipairs(patterns) do
-      if word:find('^' .. pattern) then return true end
+      if word:lower():find('^' .. pattern) then return true end
     end
   end
 

--- a/exercises/pig-latin/pig-latin_spec.lua
+++ b/exercises/pig-latin/pig-latin_spec.lua
@@ -54,7 +54,7 @@ describe('pig-latin', function()
   end)
 
   it('should ignore capitalization when translating', function()
-    assert.equal('uickQay aStFay Unray', translate('Quick FaSt rUn'))
+    assert.equal('ickQuay aStFay Unray', translate('Quick FaSt rUn'))
   end)
 
   it('should retain punctuation in translated phrases', function()


### PR DESCRIPTION
@wlspaldi noticed that the behavior wasn't correct when words were capitalized. This corrects the test and implementation.