### PR TITLE
Add tests to ensure that multi-digit run lengths are supported for en/decode

### DIFF
--- a/exercises/run-length-encoding/example.lua
+++ b/exercises/run-length-encoding/example.lua
@@ -13,7 +13,7 @@ return {
 
   decode = function(s)
     local result = ''
-    for length, c in s:gmatch('(%d?)(.)') do
+    for length, c in s:gmatch('(%d*)(.)') do
       if length == '' then length = 1 end
       result = result .. c:rep(length)
     end

--- a/exercises/run-length-encoding/run-length-encoding_spec.lua
+++ b/exercises/run-length-encoding/run-length-encoding_spec.lua
@@ -5,8 +5,16 @@ describe('run-length-encoding', function()
     assert.equal('2A3B4C', rle.encode('AABBBCCCC'))
   end)
 
+  it('should encode strings with multi-digit run lengths', function()
+    assert.equal('2A10B4C', rle.encode('AABBBBBBBBBBCCCC'))
+  end)
+
   it('should decode simple strings', function()
     assert.equal('AABBBCCCC', rle.decode('2A3B4C'))
+  end)
+
+  it('should decode strings with multi-digit run lengths', function()
+    assert.equal('AABBBBBBBBBBCCCC', rle.decode('2A10B4C'))
   end)
 
   it('should not encode characters with a run length of 1', function()


### PR DESCRIPTION
Noted by @fyrchik in http://exercism.io/submissions/b6111df3545d4af1b2ca3e8219bb8bdd