### PR TITLE
Updated Transpose exercise (test with empty lines)

### DIFF
--- a/exercises/transpose/example.lua
+++ b/exercises/transpose/example.lua
@@ -1,7 +1,7 @@
 local function Grid(s)
   local width = 0
   local rows = {}
-  for row in s:gmatch('([^\n]*)\n?') do
+  for row in s:gmatch('[^\n]*') do
     table.insert(rows, row)
     width = math.max(width, #row)
   end

--- a/exercises/transpose/example.lua
+++ b/exercises/transpose/example.lua
@@ -1,7 +1,7 @@
 local function Grid(s)
   local width = 0
   local rows = {}
-  for row in s:gmatch('[^\n]*') do
+  for row in s:gmatch('([^\n]*)\n?') do
     table.insert(rows, row)
     width = math.max(width, #row)
   end

--- a/exercises/transpose/example.lua
+++ b/exercises/transpose/example.lua
@@ -1,7 +1,7 @@
 local function Grid(s)
   local width = 0
   local rows = {}
-  for row in s:gmatch('[^\n]+') do
+  for row in s:gmatch('([^\n]*)\n?') do
     table.insert(rows, row)
     width = math.max(width, #row)
   end

--- a/exercises/transpose/transpose_spec.lua
+++ b/exercises/transpose/transpose_spec.lua
@@ -17,6 +17,22 @@ describe('transpose', function()
     assert.are.equal('S\ni\nn\ng\nl\ne\n \nl\ni\nn\ne\n.', transpose('Single line.'))
   end)
 
+  it('should transpose a string with empty lines', function()
+    local input =
+      '\n' ..
+      'Line 2\n' ..
+      '\n' ..
+      'L4'
+    local expected =
+      ' L L\n' ..
+      ' i 4\n' ..
+      ' n\n' ..
+      ' e\n' ..
+      '  \n' ..
+      ' 2'
+    assert.are.equal(expected, transpose(input))
+  end)
+
   it('should transpose a string with the first line longer than the second', function()
     local input =
       'The fourth line.\n' ..


### PR DESCRIPTION
I think this is the correct behaviour for string with empty lines, because it is reasonable to expect that `transpose(transpose(input)) == input`. If we just throw empty lines, we lose some information.

Interesting thing i noticed: if you change anything in pattern it will stop work.
Yes, `([^\n]*)` or `[^\n]*\n?` will NOT work. It is counterintuitive (especially in second case, where i just throw brackets). I don't know if this is intended behaviour in Lua.